### PR TITLE
Updated hackathon links to point to Legends of Lightning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ navs:
   - title: Makers
     url: https://makers.bolt.fun/
   - title: Hackathon
-    url: /hackathons/shock-the-web-2/
+    url: https://makers.bolt.fun/tournaments/1/overview
 
 title: BOLT.FUN
 email: lightning@peakshift.com

--- a/pages/01_landing-page/index.html
+++ b/pages/01_landing-page/index.html
@@ -93,7 +93,7 @@ permalink: /
             Quarterly hackathons to promote lightning application design and
             development.
           </p>
-          <a href="/hackathons/shock-the-web-2/"
+          <a href="https://makers.bolt.fun/tournaments/1/overview"
             >Build
             <svg viewBox="0 0 24 24">
               <use xlink:href="#svg-arrow-right"></use>


### PR DESCRIPTION
Currently there's no way to access LOL from the bolt.fun homepage. That's not right.